### PR TITLE
fix: systemd module used instead of service for correct enabling

### DIFF
--- a/tasks/make_mounts.yml
+++ b/tasks/make_mounts.yml
@@ -104,7 +104,7 @@
     mode: 0644
 
 - name: systemd | nfs | start the mount
-  ansible.builtin.service:
+  ansible.builtin.systemd_service:
     name: "{{ mount_file_name }}"
     state: "{{ mount.state | default('stopped') }}"
     enabled: "{{ mount.enabled | default(false) }}"


### PR DESCRIPTION
ansible.builtin.services module was not correctly enabling the mount, causing it to not persist past reboot. Fixed by replacing it with ansible.builtin.systemd